### PR TITLE
Hunter 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ message (STATUS "${PROJECT_NAME} version ${CONSOLE_BRIDGE_VERSION}")
 include(GNUInstallDirs)
 include(GenerateExportHeader)
 
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 # If compiler support symbol visibility, enable it.
 include(CheckCCompilerFlag)
 check_c_compiler_flag(-fvisibility=hidden HAS_VISIBILITY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,6 @@ message (STATUS "${PROJECT_NAME} version ${CONSOLE_BRIDGE_VERSION}")
 include(GNUInstallDirs)
 include(GenerateExportHeader)
 
-if (NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
 # If compiler support symbol visibility, enable it.
 include(CheckCCompilerFlag)
 check_c_compiler_flag(-fvisibility=hidden HAS_VISIBILITY)
@@ -22,7 +18,7 @@ if (HAS_VISIBILITY)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
 endif()
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT HUNTER_ENABLED)
   # Use c++11 compiler flag, since it's needed for console.cpp
   # It isn't in a header file, so it doesn't need to be exported
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
@@ -50,6 +46,10 @@ set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION
                ${CONSOLE_BRIDGE_MAJOR_VERSION}.${CONSOLE_BRIDGE_MINOR_VERSION})
 generate_export_header(${PROJECT_NAME}
     EXPORT_MACRO_NAME CONSOLE_BRIDGE_DLLAPI)
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/>
+)
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}-targets 
@@ -93,6 +93,7 @@ write_basic_config_version_file(
 
 install(EXPORT ${PROJECT_NAME}-targets
   FILE ${PROJECT_NAME}-targets.cmake
+  NAMESPACE ros::
   DESTINATION ${CMAKE_CONFIG_INSTALL_DIR})
 install(FILES
         "${CMAKE_BINARY_DIR}/${cmake_conf_file}"


### PR DESCRIPTION
Hunterising 0.4.0.

Added exported targets to a `ros::` namespace but I guess not strictly necessary so can be removed if undesired.